### PR TITLE
Handle NoteOn,Vel=0 same as NoteOff

### DIFF
--- a/src/midi/midi.c
+++ b/src/midi/midi.c
@@ -61,12 +61,16 @@ void midi_channel_apply(struct midi_message* msg)
     uint8_t midi_channel = get_midi_channel(msg->channel);
     switch (msg->command) {
     case MIDI_CMD_NOTE_ON:
-        if (getvalue.state == ACTIVE &&
-            getvalue.parameter.type == NOTE)
+        if (getvalue.state == ACTIVE && getvalue.parameter.type == NOTE) {
             getvalue.midi_note = msg->data1;
-        else {
+            getvalue.midi_note_vel = msg->data2;
+        } else {
             sequencer_midi_note = msg->data1;
-            assigner_notify_note_on(midi_channel, msg->data1);
+            if (msg->data2 == 0) {
+                assigner_notify_note_off(midi_channel, msg->data1);
+            } else {
+                assigner_notify_note_on(midi_channel, msg->data1);
+            }
         }
         break;
 

--- a/src/midi/midi.c
+++ b/src/midi/midi.c
@@ -63,7 +63,6 @@ void midi_channel_apply(struct midi_message* msg)
     case MIDI_CMD_NOTE_ON:
         if (getvalue.state == ACTIVE && getvalue.parameter.type == NOTE) {
             getvalue.midi_note = msg->data1;
-            getvalue.midi_note_vel = msg->data2;
         } else {
             sequencer_midi_note = msg->data1;
             if (msg->data2 == 0) {


### PR DESCRIPTION
Updated MIDI input code to comply with MIDI specification regarding stopping playback of notes. 
A NoteOn command with Velocity = 0 should be treated identically to NoteOff.