### PR TITLE
add compatibility for PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+.vscode/extensions.json

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,9 @@ platform = atmelavr
 board = ATmega328P
 framework = arduino
 
+board_build.f_cpu = 20000000L
+
+; for future use with serial debugging:
 ; lib_deps = https://github.com/nickgammon/SendOnlySoftwareSerial.git
 
 upload_protocol = custom

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,33 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:ATmega328P]
+platform = atmelavr
+board = ATmega328P
+framework = arduino
+
+; lib_deps = https://github.com/nickgammon/SendOnlySoftwareSerial.git
+
+upload_protocol = custom
+upload_port = /dev/ttyACM0
+upload_speed = 19200
+upload_flags =
+    -C
+    ; use "tool-avrdude-megaavr" for the atmelmegaavr platform
+    $PROJECT_PACKAGES_DIR/tool-avrdude/avrdude.conf
+    -p
+    $BOARD_MCU
+    -P
+    $UPLOAD_PORT
+    -b
+    $UPLOAD_SPEED
+    -c
+    stk500v1
+upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,8 @@ board_build.f_cpu = 20000000L
 ; lib_deps = https://github.com/nickgammon/SendOnlySoftwareSerial.git
 
 upload_protocol = custom
-upload_port = /dev/ttyACM0
+upload_port = COM5              ; Windows
+; upload_port = /dev/ttyACM0    ; Linux
 upload_speed = 19200
 upload_flags =
     -C

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ framework = arduino
 
 board_build.f_cpu = 20000000L
 
-; for future use with serial debugging:
+; for potential future use with serial debugging:
 ; lib_deps = https://github.com/nickgammon/SendOnlySoftwareSerial.git
 
 upload_protocol = custom
@@ -33,7 +33,7 @@ upload_flags =
     -b
     $UPLOAD_SPEED
     -c
-    stk500v1
+    stk500v1    ; Arduino UNO as ISP (ATmega328pu)
 upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
 
 ; fuse bit settings

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,3 +35,9 @@ upload_flags =
     -c
     stk500v1
 upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
+
+; fuse bit settings
+; ATmega328p 20MHz external
+board_fuses.lfuse = 0xE0
+board_fuses.hfuse = 0xD9
+board_fuses.efuse = 0XFF

--- a/src/apu/apu.h
+++ b/src/apu/apu.h
@@ -82,10 +82,8 @@ extern struct dmc dmc;
 
 /* Functions */
 
-void sq1_setup(void);
-void sq1_update(void);
-void sq2_setup(void);
-void sq2_update(void);
+void sq_setup(uint8_t, struct square*);
+void sq_update(struct square*);
 void tri_setup(void);
 void tri_update(void);
 void noise_setup(void);
@@ -95,6 +93,7 @@ void dmc_update(void);
 void dmc_update_sample(void);
 void apu_refresh_channel(uint8_t);
 void apu_refresh_all(void);
+void apu_update_channel(uint8_t);
 void apu_update_handler(void);
 void apu_dmc_update_handler(void);
 void apu_setup(void);

--- a/src/io/2a03.c
+++ b/src/io/2a03.c
@@ -27,7 +27,6 @@
 #include "2a03.h"
 #include <avr/io.h>
 
-#define F_CPU 20000000L
 #include <util/delay.h>
 
 #include <util/atomic.h>

--- a/src/io/2a03.h
+++ b/src/io/2a03.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2014-2015 Johan Fjeldtvedt 
+  Copyright 2014-2015 Johan Fjeldtvedt
 
   This file is part of NESIZER.
 
@@ -20,7 +20,7 @@
 
   Low level 2A03 I/O interface
 
-  Contains functions for communicating with and controlling the 
+  Contains functions for communicating with and controlling the
   2A03.
 */
 
@@ -28,6 +28,8 @@
 #pragma once
 
 #include <stdint.h>
+
+#define F_CPU 20000000L
 
 void io_register_write(uint8_t reg, uint8_t value);
 void io_write_changed(uint8_t reg);

--- a/src/io/2a03.h
+++ b/src/io/2a03.h
@@ -29,7 +29,9 @@
 
 #include <stdint.h>
 
-#define F_CPU 20000000L
+#ifndef F_CPU
+    #define F_CPU 20000000L
+#endif
 
 void io_register_write(uint8_t reg, uint8_t value);
 void io_write_changed(uint8_t reg);

--- a/src/io/ringbuffer.c
+++ b/src/io/ringbuffer.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "ringbuffer.h"
+#include "ui/ui.h"
 
 #define ERROR_RINGBUF_WRITE_OFLOW (1 << 0)
 #define ERROR_RINGBUF_READ_UFLOW (1 << 1)

--- a/src/lfo/data/sine.h
+++ b/src/lfo/data/sine.h
@@ -6,6 +6,12 @@
   Sine table for LFOs
 
  */
+
+
+#pragma once
+
+#include <avr/pgmspace.h>
+
 const int8_t sine_table[] PROGMEM = {
   0, 12, 25, 37, 49, 60, 71, 81, 90, 98, 106, 112, 117, 122, 125, 126,
   127, 126, 125, 122, 117, 112, 106, 98, 90, 81, 71, 60, 49, 37, 25, 12,

--- a/src/lfo/lfo.c
+++ b/src/lfo/lfo.c
@@ -28,7 +28,7 @@
 #include <avr/pgmspace.h>
 #include <stdint.h>
 #include "apu/apu.h"
-#include "data/sine.c"
+#include "data/sine.h"
 
 struct lfo lfo[3];
 

--- a/src/main.c
+++ b/src/main.c
@@ -42,7 +42,6 @@
 #include "settings/settings.h"
 #include "patch/patch.h"
 
-#define F_CPU 20000000L
 #include <util/delay.h>
 
 #define MAGIC 0xdeadbeef

--- a/src/midi/midi.c
+++ b/src/midi/midi.c
@@ -202,9 +202,6 @@ static inline void transfer()
   Handlers transfering of data via MIDI
 */
 {
-    static uint8_t nibble_flag = 0;
-    static uint8_t temp_val = 0;
-
     while (midi_io_bytes_remaining() >= 1) {
         uint8_t val = midi_io_read_byte();
 

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,14 @@
+.vscode/*
+samples/*
+
+convert-all-samples.sh
+
+deltacompress.exe
+deltacompress.ilk
+deltacompress.obj
+deltacompress.pdb
+gensysex.exe
+gensysex.ilk
+gensysex.obj
+gensysex.pdb
+vc140.pdb


### PR DESCRIPTION
PlatformIO for VSCode is a cross-platform IDE for microcontrollers, and I have found it much easier to use than manually installing the avr-gcc compiler and avrdude then manually burning fuses, compiling, and uploading using the CLI etc. On Linux I didn't experience too much difficulty doing all that manually, but this is the only way I have been able to get it to work on Windows.

This pull request includes configuration files sufficient to simply clone the repo, burn fuse bits, and compile/upload with just a few clicks. I also modified a few source files to fix some errors reported during compilation.

I have tested it on Windows and Linux, but I don't have a Mac to test.

Using PlatformIO with this PR might resolve the compilation issue (#17) circuitcreature reported after changing the optimization level from -O3 to -O2. I have had no compilation issues with -O2.

It should also help n00bs like me who didn't even know what fuse bits meant when I found this repo.
It will decrease the extra work required for those who just want a cool new instrument to play with.